### PR TITLE
Calling Python 3 instead of generic Python

### DIFF
--- a/bin/process.py
+++ b/bin/process.py
@@ -1,14 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding=utf-8
-
-from __future__ import print_function
-import sys
-
-# Check for version
-if sys.version_info[0] <= 2:
-    print('Only works with Python 3. Please either change the first line of /usr/bin/yauml or make `python` points toward Python 3.')
-    sys.exit(1)
-
 r"""
 Creating UML diagrams from YAML files.
 
@@ -28,7 +19,7 @@ AUTHORS:
 #                  http://www.gnu.org/licenses/                                     *
 #************************************************************************************
 
-import yaml, getopt, re, subprocess
+import sys, yaml, getopt, re, subprocess
 
 template_filename = '../templates/default.dot'
 out_file = None

--- a/bin/process.py
+++ b/bin/process.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python
 # coding=utf-8
+
+from __future__ import print_function
+import sys
+
+# Check for version
+if sys.version_info[0] <= 2:
+    print('Only works with Python 3. Please either change the first line of /usr/bin/yauml or make `python` points toward Python 3.')
+    sys.exit(1)
+
 r"""
 Creating UML diagrams from YAML files.
 
@@ -19,7 +28,7 @@ AUTHORS:
 #                  http://www.gnu.org/licenses/                                     *
 #************************************************************************************
 
-import yaml, sys, getopt, re, subprocess
+import yaml, getopt, re, subprocess
 
 template_filename = '../templates/default.dot'
 out_file = None


### PR DESCRIPTION
Since the main script depends on the Python 3 syntax and since `python` does not always point to Python 3, a more precise call is now done.

This is solved by pull request #7, but the merge should be in the dev branch instead of the master branch.